### PR TITLE
Use native Chess.com API to make move in Vue.js keyboard

### DIFF
--- a/app/src/chessboard/vue-chessboard/index.ts
+++ b/app/src/chessboard/vue-chessboard/index.ts
@@ -6,9 +6,6 @@ import {
   RED_SQUARE_COLOR,
 } from '../../utils';
 import {
-  dispatchMouseEvent,
-} from '../../dom-events';
-import {
   AnyFunction,
   IChessboard,
   TArea,

--- a/app/src/chessboard/vue-chessboard/index.ts
+++ b/app/src/chessboard/vue-chessboard/index.ts
@@ -74,25 +74,22 @@ export class VueChessboard implements IChessboard {
   }
 
   makeMove(fromSq: TArea, toSq: TArea, promotionPiece?: string) {
-    const fromCoords = squareToCoords(fromSq);
-    const pieceElement = this.element.querySelector(`.piece.square-${fromCoords.join('')}`);
-    if (pieceElement) {
-      const fromPosition = this._getSquarePosition(fromSq);
-      dispatchMouseEvent(pieceElement, 'mousedown', {
-        x: fromPosition.x,
-        y: fromPosition.y,
-      });
-
-      const toPosition = this._getSquarePosition(toSq);
-      dispatchMouseEvent(pieceElement, 'mouseup', {
-        x: toPosition.x,
-        y: toPosition.y,
-      });
-
-      if (promotionPiece) {
-        this.store.dispatch('selectPromotionPiece', promotionPiece);
-      }
-    }
+    const [fromFile, fromRank] = squareToCoords(fromSq).map(i => Number(i));
+    const [toFile, toRank] = squareToCoords(toSq).map(i => Number(i));
+    this.store.chessboard.emit('MOVE_MADE', {
+      from: {
+        file: fromFile,
+        rank: fromRank,
+      },
+      to: {
+        file: toFile,
+        rank: toRank,
+        altKey: false,
+        isRightClick: false
+      },
+      isIllegal: false,
+      promotion: promotionPiece ? promotionPiece : undefined
+    });
   }
 
   isLegalMove(fromSq: TArea, toSq: TArea) {

--- a/app/src/chessboard/vue-chessboard/types.ts
+++ b/app/src/chessboard/vue-chessboard/types.ts
@@ -277,7 +277,7 @@ export interface IVueChessboardStore {
   $el: HTMLElement
   chessboard: {
     dispatch: AnyFunction
-    emit: AnyFunction
+    emit: (event: TChessboardEvent, data?: any) => void
     extensions: Record<string, any>
     off: AnyFunction
     on: (event: TChessboardEvent, fn: AnyFunction) => void

--- a/app/src/dom-events.ts
+++ b/app/src/dom-events.ts
@@ -19,22 +19,3 @@ export function dispatchPointerEvent(
     clientY: y,
   }));
 }
-
-export function dispatchMouseEvent(
-  element: Element,
-  name: string,
-  {
-    button = MOUSE_BUTTON.left,
-    x = 0,
-    y = 0,
-  } : { button?: number, x: number, y: number },
-) {
-  element.dispatchEvent(new MouseEvent(name, {
-    bubbles: true,
-    cancelable: true,
-    view: window,
-    button,
-    clientX: x,
-    clientY: y,
-  }));
-}


### PR DESCRIPTION
Instead of synthesizing mouse events

There were a few reports about not being able to make a move:
i.e. the move is consumed into the text input without any visible error,
but no effect happens

The issue happens on Vue.js live board

I was not able to reproduce the issue, but it seems like
`makeMove` function is called, but something goes wrong inside of the function

There is an "if" condition to execute the move only
if the element was found in DOM by selector,
maybe this check fails for some reason