### PR TITLE
isFlipped from API + pointer event dispatch

### DIFF
--- a/app/src/chessboard/component-chessboard/index.ts
+++ b/app/src/chessboard/component-chessboard/index.ts
@@ -46,6 +46,11 @@ export class ComponentChessboard implements IChessboard {
     const move = { from: fromSq, to: toSq };
     const moveDetails = this.game.getMove(move);
     const isPromotion = Boolean(moveDetails.promotion);
+    
+    const fromPosition = this._getSquarePosition(fromSq);
+    const toPosition = this._getSquarePosition(toSq);
+    dispatchPointerEvent(this.element, 'pointerdown', { x: fromPosition.x, y: fromPosition.y });
+    dispatchPointerEvent(this.element, 'pointerup', { x: toPosition.x, y: toPosition.y });
 
     this.game.move({
       ...move,
@@ -182,7 +187,7 @@ export class ComponentChessboard implements IChessboard {
   }
 
   _getSquarePosition(square: TArea, fromDoc: boolean = true) {
-    const isFlipped = this.element.classList.contains('flipped');
+    const isFlipped = this.element.game.getOptions().flipped;
     const coords = squareToCoords(square);
     const {left, top, width} = this.element.getBoundingClientRect();
     const squareWidth = width / 8;


### PR DESCRIPTION
The class `flipped` is not longer available as well, the property should be obtained from the API call.

Also I insist for the dispatchings. Have you tried in rapid live games or daily games ? If I remove this chunk of code it doesn't work, and in fact this is how I discovered that the class `flipped` was not working anymore because when I was flipping the board the dispatch was sending the wrong coordinates and failed.

Also I am using Chrome Version 85.0.4183.83 (Official Build) (64-bit).