### PR TITLE
Fix markings clean up in some cases (canvas board + Escape keypress)

### DIFF
--- a/app/src/chessboard/component-chessboard/index.ts
+++ b/app/src/chessboard/component-chessboard/index.ts
@@ -11,6 +11,7 @@ import {
 } from './types';
 import {
   squareToCoords,
+  ALL_AREAS,
 } from '../../utils';
 import {
   dispatchPointerEvent,
@@ -160,6 +161,17 @@ export class ComponentChessboard implements IChessboard {
         } catch(e) {}
       }
     });
+  }
+
+  clearMarkedAreas() {
+    ALL_AREAS.forEach((area: TArea) => {
+      this.unmarkArea(area);
+    });
+  }
+
+  clearAllMarkings() {
+    this.clearMarkedAreas();
+    this.clearMarkedArrows();
   }
 
   onMove(fn: (move: IMoveDetails) => void) : void {

--- a/app/src/chessboard/component-chessboard/index.ts
+++ b/app/src/chessboard/component-chessboard/index.ts
@@ -120,7 +120,12 @@ export class ComponentChessboard implements IChessboard {
   }
 
   clearMarkedArrows() {
-    this.game.clearMarkings(['arrow']);
+    const markings = this.game.getMarkings();
+    const arrowMarkings = markings.arrow;
+    Object.values(arrowMarkings).forEach((arrow) => {
+      const { from, to } = arrow;
+      this.unmarkArrow(from, to);
+    });
   }
 
   markArea(square: TArea) {

--- a/app/src/chessboard/component-chessboard/types.ts
+++ b/app/src/chessboard/component-chessboard/types.ts
@@ -145,6 +145,8 @@ export interface IMarkingsData {
     type: "arrow"
     key: TAreaFromTo
     color: 'default' | string
+    from: string
+    to: string
     data: any
   }>
   customItem: any

--- a/app/src/chessboard/global-chessboard/index.ts
+++ b/app/src/chessboard/global-chessboard/index.ts
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import {
   RED_SQUARE_COLOR,
+  ALL_AREAS,
 } from '../../utils';
 import {
   Nullable,
@@ -103,6 +104,17 @@ export class GlobalChessboard implements IChessboard {
 
   unmarkArea(square: TArea) {
     this.board.unmarkArea(square, true);
+  }
+
+  clearMarkedAreas() {
+    ALL_AREAS.forEach((area: TArea) => {
+      this.unmarkArea(area);
+    });
+  }
+
+  clearAllMarkings() {
+    this.clearMarkedAreas();
+    this.clearMarkedArrows();
   }
 
   onMove(fn: (move: IMoveDetails) => void) : void {

--- a/app/src/chessboard/vue-chessboard/index.ts
+++ b/app/src/chessboard/vue-chessboard/index.ts
@@ -4,6 +4,7 @@ import {
   squareToCoords,
   coordsToSquare,
   RED_SQUARE_COLOR,
+  ALL_AREAS,
 } from '../../utils';
 import {
   AnyFunction,
@@ -224,6 +225,17 @@ export class VueChessboard implements IChessboard {
     if (rect) {
       rect.remove();
     }
+  }
+
+  clearMarkedAreas() {
+    ALL_AREAS.forEach((area: TArea) => {
+      this.unmarkArea(area);
+    });
+  }
+
+  clearAllMarkings() {
+    this.clearMarkedAreas();
+    this.clearMarkedArrows();
   }
 
   _getSquarePosition(square: TArea, fromDoc: boolean = true) {

--- a/app/src/keyboard.ts
+++ b/app/src/keyboard.ts
@@ -88,7 +88,7 @@ export function bindInputKeyDown(input: HTMLInputElement) {
       input.value = '';
 
       const board = getBoard();
-      board && board.clearMarkedArrows();
+      board && board.clearAllMarkings();
       e.preventDefault();
     } else if (holdingCtrlOrCmd(e)) {
       if (e.keyCode === KEY_CODES.leftArrow) {

--- a/app/src/lib/autocomplete/index.js
+++ b/app/src/lib/autocomplete/index.js
@@ -149,7 +149,11 @@ export default function Autocomplete(options){
                 return false;
             }
             // esc
-            else if (key == 27) { that.value = that.last_val; that.sc.style.display = 'none'; }
+            else if (key == 27) {
+                if (that.sc.style.display !== 'none') {
+                    that.value = that.last_val; that.sc.style.display = 'none';
+                }
+            }
             // enter
             else if (key == 13 || key == 9) {
                 var sel = that.sc.querySelector('.ccHelper-autocompleteSuggestion--selected');

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -18,6 +18,8 @@ export interface IChessboard {
   clearMarkedArrows: () => void
   markArea: (square: TArea) => void
   unmarkArea: (square: TArea) => void
+  clearMarkedAreas: () => void
+  clearAllMarkings: () => void
   onMove: (fn: (move: IMoveDetails) => void) => void
   submitDailyMove: () => void
 }

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -20,6 +20,22 @@ import { i18n } from './i18n';
 // value is stored inside of chessboard.rightClickMarkColors
 export const RED_SQUARE_COLOR = '#f42a32';
 
+export function combineStringArrays(a: string[], b: string[]) : string[] {
+  const combinations = [];
+
+  for(var i = 0; i < a.length; i++) {
+       for(var j = 0; j < b.length; j++) {
+          combinations.push(`${a[i]}${b[j]}`)
+       }
+  }
+
+  return combinations;
+}
+
+export const ALL_FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+export const ALL_RANKS = ['1', '2', '3', '4', '5', '6', '7', '8'];
+export const ALL_AREAS: TArea[] = combineStringArrays(ALL_FILES, ALL_RANKS);
+
 /**
  * Is user holding Ctrl (on PC) or Cmd (on Mac)
  */

--- a/app/test/test-chess.ts
+++ b/app/test/test-chess.ts
@@ -219,6 +219,8 @@ describe('getLegalMoves', function() {
       clearMarkedArrows: () => {},
       markArea: (square: TArea) => {},
       unmarkArea: (square: TArea) => {},
+      clearMarkedAreas: () => {},
+      clearAllMarkings: () => {},
       onMove: () => {},
       submitDailyMove: () => {},
     };


### PR DESCRIPTION
It seems that `clearMarkings(['arrow'])` call doesn't work for new canvas-based implementation of component chessboard

Also, I noticed that squares aren't cleared on Escape keydown (e.g. if you fill an ambiguous move and then press Esc)