### PR TITLE
Fix puzzles promotion

### DIFF
--- a/app/src/chess.ts
+++ b/app/src/chess.ts
@@ -98,22 +98,7 @@ export function go(board: IChessboard, input: string) : boolean {
   }
 
   const parseResult = parseMoveInput(input);
-  const moves = getLegalMoves(board, parseResult)
-    .filter(move => {
-      const vertical = squareToCoords(move.to)[1];
-
-      // Treat promotion moves without "promotionPiece" as illegal
-      if (
-        move.piece === 'p' &&
-        [1, 8].includes(vertical) &&
-        !move.promotionPiece
-      ) {
-        return false;
-      }
-
-      return true;
-    });
-
+  const moves = getLegalMoves(board, parseResult);
   if (moves.length === 1) {
     const move = moves[0];
     makeMove(board, move.from, move.to, move.promotionPiece);
@@ -156,6 +141,16 @@ export function makeMove(
  */
 export function getLegalMoves(board: IChessboard, move: Nullable<IMoveTemplate>) : IMove[] {
   if (!board || !move || !board.isPlayersMove()) {
+    return [];
+  }
+
+  // Treat promotion moves without "promotionPiece" as invalid
+  const horizontal = squareToCoords(move.to)[1];
+  if (
+    move.piece === 'p' &&
+    [1, 8].includes(horizontal) &&
+    !move.promotionPiece
+  ) {
     return [];
   }
 

--- a/app/src/chess.ts
+++ b/app/src/chess.ts
@@ -144,15 +144,7 @@ export function getLegalMoves(board: IChessboard, move: Nullable<IMoveTemplate>)
     return [];
   }
 
-  // Treat promotion moves without "promotionPiece" as invalid
-  const horizontal = squareToCoords(move.to)[1];
-  if (
-    move.piece === 'p' &&
-    [1, 8].includes(horizontal) &&
-    !move.promotionPiece
-  ) {
-    return [];
-  }
+  const toYCoord = squareToCoords(move.to)[1];
 
   if (['short-castling', 'long-castling'].includes(move.moveType)) {
     return getLegalCastlingMoves(board, move);
@@ -160,6 +152,16 @@ export function getLegalMoves(board: IChessboard, move: Nullable<IMoveTemplate>)
     const pieces = board.getPiecesSetup();
 
     const matchingPieces = filter(pieces, (p) => {
+
+      // Treat promotion moves without "promotionPiece" as invalid
+      if (
+        p.type === 'p' &&
+        [1, 8].includes(toYCoord) &&
+        !move.promotionPiece
+      ) {
+        return false;
+      }
+
       return (
         // RegExp is required, because move.piece/move.from aren't always there
         // It might be just ".", meaning "any piece" (imagine move like "e2e4")

--- a/app/src/chess.ts
+++ b/app/src/chess.ts
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual';
 import find from 'lodash/find';
 import {
   postMessage,
+  squareToCoords,
 } from './utils';
 import {
   drawCache,
@@ -97,7 +98,22 @@ export function go(board: IChessboard, input: string) : boolean {
   }
 
   const parseResult = parseMoveInput(input);
-  const moves = getLegalMoves(board, parseResult);
+  const moves = getLegalMoves(board, parseResult)
+    .filter(move => {
+      const vertical = squareToCoords(move.to)[1];
+
+      // Treat promotion moves without "promotionPiece" as illegal
+      if (
+        move.piece === 'p' &&
+        [1, 8].includes(vertical) &&
+        !move.promotionPiece
+      ) {
+        return false;
+      }
+
+      return true;
+    });
+
   if (moves.length === 1) {
     const move = moves[0];
     makeMove(board, move.from, move.to, move.promotionPiece);

--- a/app/src/chessboard/component-chessboard/index.ts
+++ b/app/src/chessboard/component-chessboard/index.ts
@@ -45,10 +45,14 @@ export class ComponentChessboard implements IChessboard {
 
   makeMove(fromSq: TArea, toSq: TArea, promotionPiece?: string) {
     const move = { from: fromSq, to: toSq };
-    const fromPosition = this._getSquarePosition(fromSq);
-    const toPosition = this._getSquarePosition(toSq);
-    dispatchPointerEvent(this.element, 'pointerdown', { x: fromPosition.x, y: fromPosition.y });
-    dispatchPointerEvent(this.element, 'pointerup', { x: toPosition.x, y: toPosition.y });
+
+    // In case of promotion only interact via JS API
+    if (!promotionPiece) {
+      const fromPosition = this._getSquarePosition(fromSq);
+      const toPosition = this._getSquarePosition(toSq);
+      dispatchPointerEvent(this.element, 'pointerdown', { x: fromPosition.x, y: fromPosition.y });
+      dispatchPointerEvent(this.element, 'pointerup', { x: toPosition.x, y: toPosition.y });
+    }
 
     this.game.move({
       ...move,

--- a/cypress/fixtures/positions.json
+++ b/cypress/fixtures/positions.json
@@ -10,5 +10,11 @@
         "positions": {
             "end": "1n1Rkb1r/p4ppp/4q3/4p1B1/4P3/8/PPP2PPP/2K5 b k - 1 17"
         }
+    },
+    "puzzles-promotion": {
+        "url": "https://www.chess.com/puzzles/problem/1007830",
+        "positions": {
+            "end": "1Q6/5kp1/4p3/4p1p1/P3P1P1/2p5/5PK1/1R6 b - - 0 36"
+        }
     }
 }

--- a/cypress/integration/bugs.spec.js
+++ b/cypress/integration/bugs.spec.js
@@ -10,33 +10,44 @@ const { INPUT_SELECTOR } = require('../constants');
 const ARROW_SELECTOR = 'img.chessBoardArrow';
 const PREV_MOVE_SELECTOR = '.prev-next-arrows-icon';
 
+function testPuzzlePromotion(cy, isAlgebraic) {
+  const promotionMoveBase = isAlgebraic ? 'b8' : 'a7b8';
+
+  cy.visit(this.positions['puzzles-promotion'].url)
+  cy.wait(2000)
+  cy.acceptCookies(2000)
+  cy.enablePuzzleBoard();
+  cy.wait(2000)
+
+  cy
+    .makeMove('c4')
+    .makeMove('b6')
+    .makeMove('c3')
+    .makeMove('a7')
+    .makeMove('Rb8')
+    .makeMove(`${promotionMoveBase}=Q`)
+    .get(PREV_MOVE_SELECTOR)
+      .first()
+      .click()
+
+  cy
+    .makeMove(promotionMoveBase)
+    .makeMove(`${promotionMoveBase}=Q`)
+    .fenEquals(this.positions['puzzles-promotion'].positions.end)
+}
+
 context('Bugs', () => {
   beforeEach(() => {
     cy.fixture('positions').as('positions')
   });
 
-  it('Puzzles promotion', function() {
+  it('Puzzles promotion (algebraic)', function() {
     // See https://github.com/everyonesdesign/Chess-Helper/issues/34
-    cy.visit(this.positions['puzzles-promotion'].url)
-    cy.wait(2000)
-    cy.acceptCookies(2000)
-    cy.enablePuzzleBoard();
-    cy.wait(2000)
+    testPuzzlePromotion.call(this, cy, true);
+  });
 
-    cy
-      .makeMove('c4')
-      .makeMove('b6')
-      .makeMove('c3')
-      .makeMove('a7')
-      .makeMove('Rb8')
-      .makeMove('b8=Q')
-      .get(PREV_MOVE_SELECTOR)
-        .first()
-        .click()
-
-    cy
-      .makeMove('b8')
-      .makeMove('b8=Q')
-      .fenEquals(this.positions['puzzles-promotion'].positions.end)
+  it('Puzzles promotion (UCI)', function() {
+    // See https://github.com/everyonesdesign/Chess-Helper/issues/34
+    testPuzzlePromotion.call(this, cy, false);
   });
 });

--- a/cypress/integration/bugs.spec.js
+++ b/cypress/integration/bugs.spec.js
@@ -1,0 +1,42 @@
+/// <reference types="cypress" />
+
+/**
+ * BUGS
+ * Checking specific issues encountered before
+ */
+
+const { INPUT_SELECTOR } = require('../constants');
+
+const ARROW_SELECTOR = 'img.chessBoardArrow';
+const PREV_MOVE_SELECTOR = '.prev-next-arrows-icon';
+
+context('Bugs', () => {
+  beforeEach(() => {
+    cy.fixture('positions').as('positions')
+  });
+
+  it('Puzzles promotion', function() {
+    // See https://github.com/everyonesdesign/Chess-Helper/issues/34
+    cy.visit(this.positions['puzzles-promotion'].url)
+    cy.wait(2000)
+    cy.acceptCookies(2000)
+    cy.enablePuzzleBoard();
+    cy.wait(2000)
+
+    cy
+      .makeMove('c4')
+      .makeMove('b6')
+      .makeMove('c3')
+      .makeMove('a7')
+      .makeMove('Rb8')
+      .makeMove('b8=Q')
+      .get(PREV_MOVE_SELECTOR)
+        .first()
+        .click()
+
+    cy
+      .makeMove('b8')
+      .makeMove('b8=Q')
+      .fenEquals(this.positions['puzzles-promotion'].positions.end)
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -8,6 +8,7 @@ addExtensionCommands(Cypress)
 const DEFAULT_MOVE_OPTIONS = {
   delay: 100,
 }
+
 Cypress.Commands.add('makeMove', (move, options = {}) => {
   const opts = Object.assign({}, options, DEFAULT_MOVE_OPTIONS)
   return cy
@@ -27,4 +28,33 @@ Cypress.Commands.add('fenEquals', (expectedFen) => {
 
 Cypress.Commands.add('flipBoard', () => {
   cy.get('body').type('x');
+})
+
+Cypress.Commands.add('acceptCookies', () => {
+  return cy.window().then((win) => {
+    try {
+      const SELECTOR = '.accept-button';
+      const buttons = win.document.querySelectorAll(SELECTOR);
+      buttons.forEach(b => b.click());
+    } catch(e) {}
+  })
+})
+
+Cypress.Commands.add('enablePuzzleBoard', () => {
+  return cy.window().then((win) => {
+    const element = win.document.querySelector('chess-board');
+
+    element.game.setOptions({ enabled: true })
+
+    const mode = element.game.getMode();
+    mode.isAllowedToMove = () => true;
+    const options = mode.getOptions();
+
+    options.canModifyExistingMovesOnMainLine = true;
+    options.canInteractWithPieces = true;
+    options.canAddMovesToMainLine = true;
+
+    element.game.canMoveForward = () => true;
+    element.game.getTurn = () => element.game.getPlayingAs();
+  })
 })


### PR DESCRIPTION
Presumably closes #34 

Changes include:

- Don't allow making promotion moves without specifying piece type (e.g. "b8" is invalid, while "b8=Q" is a valid move)
- Don't use drag/drop imitation for promotion moves (it might open promotion window and break the chessboard state)
- Cover the case with e2e tests