### PR TITLE
Persist blindfold to localStorage

### DIFF
--- a/app/inject.js
+++ b/app/inject.js
@@ -7,8 +7,8 @@ envScript.innerHTML = `
     defaultLocale: "${manifest.default_locale}",
   };
 `;
-document.body.appendChild(envScript);
 
+(document.head||document.documentElement).prepend(envScript);
 
 /**
  * injectScript - Inject internal script to available access to the `window`
@@ -16,12 +16,11 @@ document.body.appendChild(envScript);
  * @param  {type} filePath Local path of the internal script.
  * @param  {type} tag The tag as string, where the script will be append (default: 'body').
  */
-function injectScript(filePath, tag) {
-    const node = document.getElementsByTagName(tag)[0];
-    const script = document.createElement('script');
-    script.setAttribute('type', 'text/javascript');
-    script.setAttribute('src', filePath);
-    node.appendChild(script);
+function injectScript(filePath) {
+  const script = document.createElement('script');
+  script.setAttribute('type', 'text/javascript');
+  script.setAttribute('src', filePath);
+  (document.head||document.documentElement).prepend(script);
 }
 
-injectScript(chrome.extension.getURL('build.js'), 'body');
+injectScript(chrome.extension.getURL('build.js'));

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -22,7 +22,7 @@
       "js": [
         "inject.js"
       ],
-      "run_at": "document_end",
+      "run_at": "document_start",
       "css": [
         "styles/main.css"
       ]

--- a/app/src/blindfold.ts
+++ b/app/src/blindfold.ts
@@ -1,0 +1,101 @@
+import domify from 'domify';
+import {
+  blindFoldIcon,
+} from './icons';
+import {
+  blindfoldOverlays,
+} from './globals';
+import {
+  Nullable,
+  IChessboard,
+} from './types';
+import {
+  getBoard,
+} from './chessboard';
+import { i18n } from './i18n';
+
+const BLINDFOLD_STORAGE_KEY = 'ccHelper-blindfold';
+const BLINDFOLD_ENABLED_VALUE = '1';
+
+// document.body class to toggle the blindfold mode
+export const BLINDFOLD_BODY_CLASSNAME = 'ccHelper-docBody--blindfolded';
+// document.head class to toggle the blindfold mode (needed for early rendering tricks)
+export const BLINDFOLD_HEAD_CLASSNAME = 'ccHelper-docHead--blindfolded';
+
+function isBlindfoldModeEnabled() : boolean {
+  const value = localStorage.getItem(BLINDFOLD_STORAGE_KEY);
+  return value === BLINDFOLD_ENABLED_VALUE;
+}
+
+function setBlindfoldModeState(state : boolean) : void {
+  localStorage.setItem(BLINDFOLD_STORAGE_KEY, state ? '1' : '0');
+  renderBlindfold();
+}
+
+export function toggleBlindfoldMode() : void {
+  const isEnabled = isBlindfoldModeEnabled();
+  setBlindfoldModeState(!isEnabled);
+}
+
+export function renderBlindfold() : void {
+  const isEnabled = isBlindfoldModeEnabled();
+  const method = isEnabled ? 'add' : 'remove';
+
+  if (document.body) {
+    document.body.classList[method](BLINDFOLD_BODY_CLASSNAME);
+  }
+
+  if (document.head) {
+    document.head.classList[method](BLINDFOLD_HEAD_CLASSNAME);
+  }
+
+  if (isEnabled) {
+    const board = getBoard();
+    board && initBlindFoldOverlay(board);
+  }
+}
+
+/**
+ * Create a blindfold overlay for a board element
+ */
+export function initBlindFoldOverlay(board: IChessboard) {
+  const existingOverlay = blindfoldOverlays.get(board);
+  if (!existingOverlay) {
+    const container = board.getRelativeContainer();
+    if (container) {
+      if (container) {
+        const overlay = domify(`
+          <div class="ccHelper-blindfold">
+            <div class="ccHelper-blindfoldPeek">
+              <div class="ccHelper-blindfoldPeekContents">
+                ${i18n('blindFoldPeekHint', {
+                  key: '<span class="ccHelper-blindfoldKey">Ctrl</span>'
+                })}
+              </div>
+            </div>
+            <div class="ccHelper-blindfoldBackground"></div>
+            <div class="ccHelper-blindfoldTitle">
+              ${i18n('blindFoldOn')}
+            </div>
+            ${blindFoldIcon}
+            <button class="ccHelper-blindfoldButton">
+              ${i18n('blindfoldToggleHint')}
+            </button>
+          </div>
+        `);
+
+        // toggle blindfold mode on button click...
+        const button = overlay.querySelector('.ccHelper-blindfoldButton');
+        if (button) {
+          button.addEventListener('click', toggleBlindfoldMode);
+        }
+
+        blindfoldOverlays.set(board, overlay);
+        container.appendChild(overlay);
+      } else {
+        // maybe set some dummy value to `blindfoldOverlays` set
+        // to optimise this function?
+      }
+    }
+  }
+}

--- a/app/src/commands.ts
+++ b/app/src/commands.ts
@@ -2,14 +2,15 @@ import {
   postMessage,
 } from './utils';
 import {
+  toggleBlindfoldMode,
+} from './blindfold';
+import {
   Nullable,
 } from './types';
 import { i18n } from './i18n';
 
 export const commands : Record<string, () => void> = {
-  blindfold: () => {
-    document.body.classList.toggle('ccHelper-docBody--blindfolded');
-  },
+  blindfold: toggleBlindfoldMode,
   resign: () => {
     const resignButton = <Nullable<HTMLButtonElement>>document.querySelector('.resign-button-component');
     resignButton && resignButton.click();

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -11,18 +11,22 @@ import {
   bindBlindFoldPeek,
 } from './keyboard';
 import {
+  onDocumentReady,
   isEditable,
   buildMessagesMarkup,
   createInitialElements,
   startUpdatingAriaHiddenElements,
-  initBlindFoldOverlay,
+  markExtentionInit,
 } from './utils';
 import {
   commands,
 } from './commands';
+import {
+  initBlindFoldOverlay,
+  renderBlindfold,
+} from './blindfold';
 import autocomplete from './lib/autocomplete';
 import { i18n } from './i18n';
-
 
 /**
  * Prepare the extension code and run
@@ -77,7 +81,6 @@ function init() {
 
         if (board) {
           drawMovesOnBoard(board, input.value);
-          initBlindFoldOverlay(board);
         }
       } catch (e) {
         console.error(e);
@@ -93,7 +96,10 @@ function init() {
     });
 
     buildMessagesMarkup();
+    renderBlindfold();
   }
+
+  markExtentionInit();
 }
 
 /**
@@ -114,4 +120,7 @@ function updatePlaceholder(unfocusedLabel: HTMLElement) {
   }
 }
 
-setTimeout(init, 500);
+onDocumentReady(() => {
+  renderBlindfold();
+  setTimeout(init, 500);
+});

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -22,7 +22,6 @@ import {
   commands,
 } from './commands';
 import {
-  initBlindFoldOverlay,
   renderBlindfold,
 } from './blindfold';
 import autocomplete from './lib/autocomplete';

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -1,16 +1,11 @@
 import domify from 'domify';
 import {
   ariaHiddenElements,
-  blindfoldOverlays,
 } from './globals';
-import {
-  blindFoldIcon,
-} from './icons';
 import {
   commands,
 } from './commands';
 import {
-  IChessboard,
   TArea,
   Nullable,
   IConfig,
@@ -63,6 +58,30 @@ export function postMessage(text: string) {
       messagesContainer.removeChild(message);
     }, 3000);
   }
+}
+
+
+/**
+ * Run callback on document ready
+ * See https://stackoverflow.com/a/989970
+ */
+export function onDocumentReady(fn: () => void) : void {
+    if (document.readyState === "complete" || document.readyState === "interactive") {
+        setTimeout(fn, 1);
+    } else {
+        document.addEventListener("DOMContentLoaded", fn);
+    }
+}
+
+/**
+ * Mark finishing of extension init
+ * Can be used for styles tweaks
+ */
+export const EXTENTION_INITED_BODY_CLASSNAME = 'ccHelper-docBody--inited';
+export const EXTENTION_INITED_HEAD_CLASSNAME = 'ccHelper-docHead--inited';
+export function markExtentionInit() : void {
+  document.head.classList.add(EXTENTION_INITED_HEAD_CLASSNAME);
+  document.body.classList.add(EXTENTION_INITED_BODY_CLASSNAME);
 }
 
 /**
@@ -136,51 +155,6 @@ export function startUpdatingAriaHiddenElements() {
 
   update();
   setInterval(update, 1000);
-}
-
-/**
- * Create a blindfold overlay for a board element
- */
-export function initBlindFoldOverlay(board: IChessboard) {
-  const existingOverlay = blindfoldOverlays.get(board);
-  if (!existingOverlay) {
-    const container = board.getRelativeContainer();
-    if (container) {
-      if (container) {
-        const overlay = domify(`
-          <div class="ccHelper-blindfold">
-            <div class="ccHelper-blindfoldPeek">
-              <div class="ccHelper-blindfoldPeekContents">
-                ${i18n('blindFoldPeekHint', {
-                  key: '<span class="ccHelper-blindfoldKey">Ctrl</span>'
-                })}
-              </div>
-            </div>
-            <div class="ccHelper-blindfoldBackground"></div>
-            <div class="ccHelper-blindfoldTitle">
-              ${i18n('blindFoldOn')}
-            </div>
-            ${blindFoldIcon}
-            <button class="ccHelper-blindfoldButton">
-              ${i18n('blindfoldToggleHint')}
-            </button>
-          </div>
-        `);
-
-        // toggle blindfold mode on button click...
-        const button = overlay.querySelector('.ccHelper-blindfoldButton');
-        if (button) {
-          button.addEventListener('click', () => commands.blindfold());
-        }
-
-        blindfoldOverlays.set(board, overlay);
-        container.appendChild(overlay);
-      } else {
-        // maybe set some dummy value to `blindfoldOverlays` set
-        // to optimise this function?
-      }
-    }
-  }
 }
 
 /**

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -82,6 +82,19 @@ input[type="text"].ccHelper-input::placeholder {
     overflow: hidden;
 }
 
+/*
+ * Hide the pieces position if the blindfold is on
+ * and the extension is not yet enabled
+ */
+.ccHelper-docHead--blindfolded:not(.ccHelper-docHead--inited) .chessboard,
+.ccHelper-docHead--blindfolded:not(.ccHelper-docHead--inited) .board:not(chess-board),
+.ccHelper-docHead--blindfolded:not(.ccHelper-docHead--inited) chess-board,
+.ccHelper-docHead--blindfolded:not(.ccHelper-docHead--inited) + body .chessboard,
+.ccHelper-docHead--blindfolded:not(.ccHelper-docHead--inited) + body .board:not(chess-board),
+.ccHelper-docHead--blindfolded:not(.ccHelper-docHead--inited) + body chess-board {
+    opacity: .01;
+}
+
 .ccHelper-blindfold {
     position: absolute;
     display: flex;

--- a/cypress/integration/analysis.spec.js
+++ b/cypress/integration/analysis.spec.js
@@ -12,7 +12,8 @@ const ARROW_SELECTOR = 'img.chessBoardArrow';
 const E2E4_ARROW_SELECTOR = 'chess-board .arrows [data-arrow="e2e4"]';
 const SQUARE_SELECTOR = 'chess-board [class^="highlight square-"][style*="background-color: rgb(235, 97, 80)"]';
 const BLINDFOLD_SELECTOR = '.ccHelper-blindfold';
-const BLINDFOLD_BODY_SELECTOR = '.ccHelper-blindfold';
+const BLINDFOLD_BODY_CLASS = 'ccHelper-docBody--blindfolded';
+const BLINDFOLD_HEAD_CLASS = 'ccHelper-docHead--blindfolded';
 
 context('Analysis page', () => {
   beforeEach(() => {
@@ -90,31 +91,40 @@ context('Analysis page', () => {
       .fenEquals('r1bqkbnr/pppp1ppp/2n5/4p3/4P3/2N5/PPPPNPPP/R1BQKB1R b KQkq - 3 3')
   });
 
-  it('enables blindfold mode', function() {
+  it('toggles blindfold mode', function() {
     cy
       .get(BLINDFOLD_SELECTOR)
       .should('not.exist')
+    cy
+      .get('head')
+      .should('not.have.class', BLINDFOLD_HEAD_CLASS)
+    cy
+      .get('body')
+      .should('not.have.class', BLINDFOLD_BODY_CLASS)
+
 
     // TOGGLE ON
     cy.makeMove('/blindfold')
-
     cy
       .get(BLINDFOLD_SELECTOR)
       .should('exist')
-
+    cy
+      .get('head')
+      .should('have.class', BLINDFOLD_HEAD_CLASS)
     cy
       .get('body')
-      .should('have.class', 'ccHelper-docBody--blindfolded')
+      .should('have.class', BLINDFOLD_BODY_CLASS)
 
     // TOGGLE OFF
     cy.makeMove('/blindfold')
-
     cy
       .get(BLINDFOLD_SELECTOR)
       .should('exist')
-
+    cy
+      .get('head')
+      .should('not.have.class', BLINDFOLD_HEAD_CLASS)
     cy
       .get('body')
-      .should('not.have.class', 'ccHelper-docBody--blindfolded')
+      .should('not.have.class', BLINDFOLD_BODY_CLASS)
   });
 });


### PR DESCRIPTION
After the /blindfold mode is enabled, keep it on for all the page reloads

The suggestion comes from the review to the extension: [see all reviews](https://chrome.google.com/webstore/detail/chesscom-keyboard/bghaancnengidpcefpkbbppinjmfnlhh)