### PR TITLE
Allow lower case piece letter

### DIFF
--- a/app/src/chess.ts
+++ b/app/src/chess.ts
@@ -261,7 +261,13 @@ export function parseAlgebraic(input: string) : Nullable<IMoveTemplate> {
     return null;
   }
 
-  const trimmedMove = input.replace(/[\s\-\(\)]+/g, '');
+  const trimmedMove = function() {
+    var trimmed = input.replace(/[\s\-\(\)]+/g, '');
+    if (/^[rqknb][a-h]/.test(trimmed)){
+      trimmed = trimmed[0].toUpperCase() + trimmed.slice(1);
+    }
+    return trimmed;
+  }();
 
   if (/[o0][o0][o0]/i.test(trimmedMove)) {
     return {

--- a/app/test/test-chess.ts
+++ b/app/test/test-chess.ts
@@ -159,6 +159,27 @@ describe('parseAlgebraic', function() {
     });
   });
 
+  it('allows lowercase piece letter if unambiguous', function() {
+    assert.deepEqual(parseAlgebraic('b3'), {
+      piece: 'p',
+      from: '..',
+      to: 'b3',
+      moveType: 'move',
+    });
+    assert.deepEqual(parseAlgebraic('Bb3'), {
+      piece: 'b',
+      from: '..',
+      to: 'b3',
+      moveType: 'move',
+    });
+    assert.deepEqual(parseAlgebraic('bb3'), {
+      piece: 'b',
+      from: '..',
+      to: 'b3',
+      moveType: 'move',
+    });
+  });
+
   it('returns null for UCI', function() {
     assert.strictEqual(parseAlgebraic('e2e4'), null);
   });


### PR DESCRIPTION
In algebraic notation if the result is not ambiguous.

Includes tests.

The change is really minor. Should there be more case-tolerant input elsewhere?