### PR TITLE
Pawn vs bishop ambiguity

### DIFF
--- a/app/src/chess.ts
+++ b/app/src/chess.ts
@@ -273,17 +273,22 @@ export function parseAlgebraic(input: string): IPotentialMoves {
       promotion,
     ] = pawnResult;
 
-    const move: IMoveTemplate = {
-      piece: 'p',
-      from: <TArea>`${fromFile || '.'}.`,
-      to: <TArea>`${toFile || '.'}${toRank || '.'}`,
-    };
+    if (fromFile === toFile) {
+      // Do nothing
+      // This disables moves like `bb4` for pawns to avoid ambiguity with bishops
+    } else {
+      const move: IMoveTemplate = {
+        piece: 'p',
+        from: <TArea>`${fromFile || '.'}.`,
+        to: <TArea>`${toFile || '.'}${toRank || '.'}`,
+      };
 
-    if (promotion) {
-      move.promotionPiece = <TPiece>promotion[1].toLowerCase();
+      if (promotion) {
+        move.promotionPiece = <TPiece>promotion[1].toLowerCase();
+      }
+
+      moves.push(move);
     }
-
-    moves.push(move);
   }
 
   const pieceRegex = /^([RQKNBrqknb])([a-h])?([1-8])?(x)?([a-h])([1-8])?[+#]?$/;

--- a/app/src/chess.ts
+++ b/app/src/chess.ts
@@ -265,18 +265,18 @@ export function parseAlgebraic(input: string): IPotentialMoves {
   if (pawnResult) {
     const [
       _,
-      fromHor,
+      fromFile,
       isCapture,
-      toHor,
-      toVer,
+      toFile,
+      toRank,
       enPassant,
       promotion,
     ] = pawnResult;
 
     const move: IMoveTemplate = {
       piece: 'p',
-      from: <TArea>`${fromHor || '.'}.`,
-      to: <TArea>`${toHor || '.'}${toVer || '.'}`,
+      from: <TArea>`${fromFile || '.'}.`,
+      to: <TArea>`${toFile || '.'}${toRank || '.'}`,
     };
 
     if (promotion) {
@@ -292,17 +292,17 @@ export function parseAlgebraic(input: string): IPotentialMoves {
     const [
       _,
       pieceName,
-      fromHor,
+      fromFile,
       fromVer,
       isCapture,
-      toHor,
-      toVer,
+      toFile,
+      toRank,
     ] = pieceResult;
 
     moves.push({
       piece: <TPiece>(pieceName).toLowerCase(),
-      from: <TArea>`${fromHor || '.'}${fromVer || '.'}`,
-      to: <TArea>`${toHor || '.'}${toVer || '.'}`,
+      from: <TArea>`${fromFile || '.'}${fromVer || '.'}`,
+      to: <TArea>`${toFile || '.'}${toRank || '.'}`,
     });
   }
 

--- a/app/test/test-chess.ts
+++ b/app/test/test-chess.ts
@@ -201,12 +201,9 @@ describe('parseAlgebraic', function() {
       ]);
     });
     it('bxb3', function () {
+      // "From file" coordinate is redundant in case of a pawn move
+      // Thus moves like that are interpreted as bishop moves
       assert.deepEqual(parseAlgebraic('bxb3'), [
-        {
-          piece: 'p',
-          from: 'b.',
-          to: 'b3',
-        },
         {
           piece: 'b',
           from: '..',

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,19 @@ Cypress.Commands.add('fenEquals', (expectedFen) => {
     .should('eq', expectedFen)
 })
 
+Cypress.Commands.add('setAnalysisFen', (fen) => {
+  const SHORT_DELAY = 50;
+  return cy
+    .contains('Load FEN')
+    .click()
+    .wait(SHORT_DELAY)
+    .get('[aria-label="Paste FEN"]')
+    .type(`${fen}{enter}`)
+    .get('.load-from-fen-button')
+    .click()
+    .wait(SHORT_DELAY)
+})
+
 Cypress.Commands.add('flipBoard', () => {
   cy.get('body').type('x');
 })


### PR DESCRIPTION
Interpret moves like `bb3` as bishop moves

See https://www.chess.com/forum/view/general/keyboard-controls-for-chess-com-chess-com-keyboard-browser-extension?newCommentCount=1&page=2#comment-64840439