### PR TITLE
blindfold toggle keybinding + initial wait

### DIFF
--- a/app/_locales/en/index.ts
+++ b/app/_locales/en/index.ts
@@ -10,7 +10,7 @@ const translations : TLocaleSet = {
   incorrectMove: 'Incorrect move: $move',
   illegalMove: 'Move $move is illegal',
   commandNotFound: "Can't find command $command",
-  blindFoldPeekHint: 'Hover here or hold $key to peek',
+  blindFoldPeekHint: 'Hover here or hold $key to peek, use $toggleKey to toggle on/off.',
   blindFoldOn: 'Blindfold mode is on',
   blindfoldToggleHint: 'Click here or type /blindfold to toggle',
   _test: 'Test content',

--- a/app/src/blindfold.ts
+++ b/app/src/blindfold.ts
@@ -76,7 +76,8 @@ export function initBlindFoldOverlay(board: IChessboard) {
             <div class="ccHelper-blindfoldPeek">
               <div class="ccHelper-blindfoldPeekContents">
                 ${i18n('blindFoldPeekHint', {
-                  key: '<span class="ccHelper-blindfoldKey">Ctrl</span>'
+                  key: '<span class="ccHelper-blindfoldKey">Ctrl</span>',
+                  toggleKey: '<span class="ccHelper-blindfoldKey">Ctrl+b</span>'
                 })}
               </div>
             </div>

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -30,7 +30,9 @@ import { i18n } from './i18n';
 /**
  * Prepare the extension code and run
  */
-function init() {
+async function init() {
+  await new Promise(r => setTimeout(r, 1000))
+
   const selector = `
     .analysis-diagram .chess_viewer,
     .main-board .board,

--- a/app/src/keyboard.ts
+++ b/app/src/keyboard.ts
@@ -12,6 +12,7 @@ import {
 import {
   Nullable,
 } from './types';
+import { toggleBlindfoldMode } from './blindfold';
 
 const KEY_CODES = {
   enter: 13,
@@ -133,4 +134,11 @@ export function bindBlindFoldPeek(input: HTMLInputElement) {
   // we want to duplicate these listeners
   input.addEventListener('keydown', updatePeekClass);
   input.addEventListener('keyup', updatePeekClass);
+
+  // Ctrl+b to toggle the blindfold
+  document.body.addEventListener('keypress', function (e) {
+    if (e.ctrlKey && e.code == 'KeyB') {
+      toggleBlindfoldMode()
+    }
+  })
 }


### PR DESCRIPTION
In this pull request, I added 2 things : 

- An initial wait in the `init` function. For some reasons chess.com is updating the chessboard 2 times on page load, it makes the blindfold state useless. I saw you are using a localstorage to save the toggle value, waiting makes sure the blindfold is loaded back on page refresh.

- A keyboard shortcut (ctrl+b) for toggling on/off the blindfold as well. I've updated the UI to make sure users know about this new shortcut.

What do you think?