### PR TITLE
Add confirm and cancel commands for daily games

### DIFF
--- a/app/src/commands.ts
+++ b/app/src/commands.ts
@@ -19,6 +19,14 @@ export const commands : Record<string, () => void> = {
     const drawButton = <Nullable<HTMLButtonElement>>document.querySelector('.draw-button-component');
     drawButton && drawButton.click();
   },
+  cancel: () => {
+    const cancelButton = <Nullable<HTMLButtonElement>>document.querySelector('.daily-confirm-move-buttons .cc-button-secondary')
+    cancelButton && cancelButton.click()
+  },
+  confirm: () => {
+    const confirmButton = <Nullable<HTMLButtonElement>>document.querySelector('.daily-confirm-move-buttons .cc-button-primary')
+    confirmButton && confirmButton.click()
+  }
 };
 
 /**

--- a/app/test/test-chessboard.ts
+++ b/app/test/test-chessboard.ts
@@ -3,9 +3,7 @@ import assert from 'assert';
 
 jsDomGlobal();
 
-const {
-  GlobalChessboard,
-} = require('../src/chessboard');
+import { GlobalChessboard } from '../src/chessboard'
 
 describe('GlobalChessboard', function() {
   describe('isPlayersMove', function() {

--- a/app/test/test-i18n.ts
+++ b/app/test/test-i18n.ts
@@ -3,9 +3,7 @@ import assert from 'assert';
 
 jsDomGlobal();
 
-const {
-  i18n,
-} = require('../src/i18n');
+import { i18n } from '../src/i18n';
 
 describe('Language modules', function() {
   describe('i18n', function() {


### PR DESCRIPTION
This PR introduces two new commands: `confirm` and `cancel`, to handle daily game functionality referenced in #76.

Please let me know if you'd like me to change anything.

### Changes
- Added confirm and cancel command by clicking their respective buttons, similar to the draw and resign commands.
- Updated two imports to use ES module syntax to resolve test execution issues in my environment.


https://github.com/user-attachments/assets/89f3c128-396c-443b-abef-c66a0375de9a
